### PR TITLE
Info o odleglosci od agenta do kawalka

### DIFF
--- a/Dokumentacja/Reguly.tex
+++ b/Dokumentacja/Reguly.tex
@@ -51,7 +51,7 @@ Projekty generowane są na początku rozgrywki, identyczne dla każdej drużyny.
     \item Próba ruchu poza planszę skutkuje brakiem ruchu
     \item Próba poruszenia się na pole zajęte przez innego agenta skutkuje brakiem ruchu
     \item Próba poruszenia się dwóch różnych agentów na te samo pole skutkuje poruszeniem się jednego z nich, wybór agenta do poruszenia jest dowolny
-    \item Agent wchodzący do pola otrzymuje odległość tego pola od najbliższego kawałka
+    \item Agent wchodzący do pola otrzymuje odległość tego pola od najbliższego kawałka który może podnieść
 \end{itemize}
 \subsection{Fragmenty}
 \begin{itemize}


### PR DESCRIPTION
Uściślenie dokumentacji: Wchodząc na pole gracz otrzymuje odległość od najbliższego kawałka który może podnieść. 
#69 